### PR TITLE
Fix Teamdesk call handling when queue timeout < agent timeout

### DIFF
--- a/src/mod/applications/mod_callcenter/mod_callcenter.c
+++ b/src/mod/applications/mod_callcenter/mod_callcenter.c
@@ -481,6 +481,8 @@ struct cc_queue {
 	switch_xml_config_item_t config[CC_QUEUE_CONFIGITEM_COUNT];
 	switch_xml_config_string_options_t config_str_pool;
 
+	switch_bool_t fast_callcenter;
+
 };
 typedef struct cc_queue cc_queue_t;
 
@@ -582,6 +584,9 @@ cc_queue_t *queue_set_config(cc_queue_t *queue)
 	SWITCH_CONFIG_SET_ITEM(queue->config[i++], "agent-no-answer-status", SWITCH_CONFIG_STRING, 0, &queue->agent_no_answer_status, cc_agent_status2str(CC_AGENT_STATUS_ON_BREAK), &queue->config_str_pool, NULL, NULL);
 
 	SWITCH_CONFIG_SET_ITEM(queue->config[i++], "skip-agents-with-external-calls", SWITCH_CONFIG_BOOL, 0, &queue->skip_agents_with_external_calls, SWITCH_TRUE, NULL, NULL, NULL);
+
+	SWITCH_CONFIG_SET_ITEM(queue->config[i++], "fast_callcenter", SWITCH_CONFIG_BOOL, 0, &queue->fast_callcenter, SWITCH_FALSE, NULL, NULL, NULL);
+
 
 	switch_assert(i < CC_QUEUE_CONFIGITEM_COUNT);
 
@@ -2870,11 +2875,21 @@ void *SWITCH_THREAD_FUNC cc_member_thread_run(switch_thread_t *thread, void *obj
 			/* timeout reached, check if we're originating at this time and give caller a one more chance */
 			if (switch_channel_test_app_flag_key(CC_APP_KEY, member_channel, CC_APP_AGENT_CONNECTING)) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(member_session), SWITCH_LOG_DEBUG, "Member %s <%s> in queue '%s' reached max wait time and we're connecting, waiting for agent to be connected...\n", m->member_cid_name, m->member_cid_number, m->queue_name);
-				for (;;) {
-					if (!switch_channel_test_app_flag_key(CC_APP_KEY, member_channel, CC_APP_AGENT_CONNECTING)) {
-						break;
+				if (!queue->fast_callcenter) {
+					// Wait until the agent is connected or timed out
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(member_session), SWITCH_LOG_DEBUG,
+									  "Waiting for agent to connect or timeout...\n");
+					for (;;) {
+						if (!switch_channel_test_app_flag_key(CC_APP_KEY, member_channel, CC_APP_AGENT_CONNECTING)) {
+							break;
+						}
+						switch_cond_next();
 					}
-					switch_cond_next();
+				} else {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(member_session), SWITCH_LOG_DEBUG,
+									  "Member %s <%s> in queue '%s' reached max wait time and we're connecting, but "
+									  "fast callcenter is enabled, so we don't wait for agent to be connected...\n",
+									  m->member_cid_name, m->member_cid_number, m->queue_name);
 				}
 			}
 			if (!switch_channel_test_flag(member_channel, CF_BRIDGED)) {
@@ -4109,6 +4124,7 @@ SWITCH_STANDARD_JSON_API(json_callcenter_config_function)
 			cJSON_AddItemToObject(o, "record_template", cJSON_CreateString(queue->record_template));
 			cJSON_AddItemToObject(o, "skip_agents_with_external_calls", cJSON_CreateString(queue->skip_agents_with_external_calls ? "true" : "false"));
 			cJSON_AddItemToObject(o, "agent_no_answer_status", cJSON_CreateString(queue->agent_no_answer_status));
+			cJSON_AddItemToObject(o, "fast_callcenter", cJSON_CreateString(queue->fast_callcenter ? "true" : "false"));
 			cJSON_AddItemToArray(reply, o);
 			queue = NULL;
         }


### PR DESCRIPTION
Previously, calls were not moved to the next Teamdesk when the queue timeout was reached, if the queue timeout was smaller than the agent's timeout. https://dev.azure.com/c4bag/C4B%20UC/_workitems/edit/9628/