### PR TITLE
Xcc 1.10.12 v10/bug/15576 dtls originate loop hang

### DIFF
--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -762,6 +762,21 @@ static uint8_t check_channel_status(originate_global_t *oglobals, uint32_t len, 
 		}
 
 		state = switch_channel_get_state(oglobals->originate_status[i].peer_channel);
+
+		/* C4B DEBUG: log peer channel state on every check */
+		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+			"C4B_DBG check_channel_status: peer[%d/%d] uuid=%s name=%s state=%s(%d) CF_ORIGINATING=%d CF_TRANSFER=%d CF_REDIRECT=%d CF_BRIDGED=%d hups=%d\n",
+			i, len,
+			switch_channel_get_uuid(oglobals->originate_status[i].peer_channel),
+			switch_channel_get_name(oglobals->originate_status[i].peer_channel),
+			switch_channel_state_name(state), (int)state,
+			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_ORIGINATING) ? 1 : 0,
+			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_TRANSFER) ? 1 : 0,
+			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_REDIRECT) ? 1 : 0,
+			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_BRIDGED) ? 1 : 0,
+			oglobals->hups);
+		/* END C4B DEBUG */
+
 		if (state >= CS_HANGUP || state == CS_RESET || switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_TRANSFER) ||
 			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_REDIRECT) ||
 			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_BRIDGED) ||
@@ -865,6 +880,12 @@ static uint8_t check_channel_status(originate_global_t *oglobals, uint32_t len, 
 	} else {
 		rval = 1;
 	}
+
+	/* C4B DEBUG: log check_channel_status result */
+	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
+		"C4B_DBG check_channel_status: result=%d hups=%d pickups_no_tl=%d len=%d\n",
+		rval, oglobals->hups, pickups_without_timelimit, len);
+	/* END C4B DEBUG */
 
   end:
 
@@ -3341,10 +3362,23 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 				soft_holding = switch_channel_get_variable(caller_channel, SWITCH_SOFT_HOLDING_UUID_VARIABLE);
 			}
 
+			{ /* C4B DEBUG scope */
+			time_t last_debug_elapsed = -1;
+
 			while ((!caller_channel || switch_channel_ready(caller_channel) || switch_channel_test_flag(caller_channel, CF_XFER_ZOMBIE)) &&
 					check_channel_status(&oglobals, and_argc, &force_reason, start)) {
 				time_t elapsed = switch_epoch_time_now(NULL) - start;
 				read_packet = 0;
+
+				/* C4B DEBUG: log once per second */
+				if (elapsed != last_debug_elapsed) {
+					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(oglobals.session), SWITCH_LOG_WARNING,
+						"C4B_DBG originate_loop: elapsed=%ld timelimit=%u hups=%d idx=%d and_argc=%d caller_ready=%d\n",
+						(long)elapsed, timelimit_sec, oglobals.hups, oglobals.idx, and_argc,
+						caller_channel ? switch_channel_ready(caller_channel) : -1);
+					last_debug_elapsed = elapsed;
+				}
+				/* END C4B DEBUG */
 
 				if (cancel_cause && *cancel_cause > 0) {
 					if (force_reason == SWITCH_CAUSE_NONE) {
@@ -3589,6 +3623,8 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 					switch_yield(20000);
 				}
 			}
+
+			} /* END C4B DEBUG scope */
 
 		  notready:
 

--- a/src/switch_ivr_originate.c
+++ b/src/switch_ivr_originate.c
@@ -762,21 +762,6 @@ static uint8_t check_channel_status(originate_global_t *oglobals, uint32_t len, 
 		}
 
 		state = switch_channel_get_state(oglobals->originate_status[i].peer_channel);
-
-		/* C4B DEBUG: log peer channel state on every check */
-		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-			"C4B_DBG check_channel_status: peer[%d/%d] uuid=%s name=%s state=%s(%d) CF_ORIGINATING=%d CF_TRANSFER=%d CF_REDIRECT=%d CF_BRIDGED=%d hups=%d\n",
-			i, len,
-			switch_channel_get_uuid(oglobals->originate_status[i].peer_channel),
-			switch_channel_get_name(oglobals->originate_status[i].peer_channel),
-			switch_channel_state_name(state), (int)state,
-			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_ORIGINATING) ? 1 : 0,
-			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_TRANSFER) ? 1 : 0,
-			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_REDIRECT) ? 1 : 0,
-			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_BRIDGED) ? 1 : 0,
-			oglobals->hups);
-		/* END C4B DEBUG */
-
 		if (state >= CS_HANGUP || state == CS_RESET || switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_TRANSFER) ||
 			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_REDIRECT) ||
 			switch_channel_test_flag(oglobals->originate_status[i].peer_channel, CF_BRIDGED) ||
@@ -880,12 +865,6 @@ static uint8_t check_channel_status(originate_global_t *oglobals, uint32_t len, 
 	} else {
 		rval = 1;
 	}
-
-	/* C4B DEBUG: log check_channel_status result */
-	switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_WARNING,
-		"C4B_DBG check_channel_status: result=%d hups=%d pickups_no_tl=%d len=%d\n",
-		rval, oglobals->hups, pickups_without_timelimit, len);
-	/* END C4B DEBUG */
 
   end:
 
@@ -3362,23 +3341,10 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 				soft_holding = switch_channel_get_variable(caller_channel, SWITCH_SOFT_HOLDING_UUID_VARIABLE);
 			}
 
-			{ /* C4B DEBUG scope */
-			time_t last_debug_elapsed = -1;
-
 			while ((!caller_channel || switch_channel_ready(caller_channel) || switch_channel_test_flag(caller_channel, CF_XFER_ZOMBIE)) &&
 					check_channel_status(&oglobals, and_argc, &force_reason, start)) {
 				time_t elapsed = switch_epoch_time_now(NULL) - start;
 				read_packet = 0;
-
-				/* C4B DEBUG: log once per second */
-				if (elapsed != last_debug_elapsed) {
-					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(oglobals.session), SWITCH_LOG_WARNING,
-						"C4B_DBG originate_loop: elapsed=%ld timelimit=%u hups=%d idx=%d and_argc=%d caller_ready=%d\n",
-						(long)elapsed, timelimit_sec, oglobals.hups, oglobals.idx, and_argc,
-						caller_channel ? switch_channel_ready(caller_channel) : -1);
-					last_debug_elapsed = elapsed;
-				}
-				/* END C4B DEBUG */
 
 				if (cancel_cause && *cancel_cause > 0) {
 					if (force_reason == SWITCH_CAUSE_NONE) {
@@ -3623,8 +3589,6 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_originate(switch_core_session_t *sess
 					switch_yield(20000);
 				}
 			}
-
-			} /* END C4B DEBUG scope */
 
 		  notready:
 

--- a/src/switch_rtp.c
+++ b/src/switch_rtp.c
@@ -7634,6 +7634,82 @@ static int rtp_common_read(switch_rtp_t *rtp_session, switch_payload_t *payload_
 
 			}
 			poll_loop = 0;
+
+			/* C4B patch: Return CNG frame during DTLS handshake to unblock callers.
+			 *
+			 * Problem:
+			 * --------
+			 * When a WebRTC session (A leg) is in the originate/bridge loop
+			 * (switch_ivr_originate.c:~3368), the loop calls
+			 * switch_core_session_read_frame() on the A leg before checking
+			 * B leg channel status via check_channel_status(). This enters
+			 * rtp_common_read() here. During the DTLS handshake, ICE/STUN
+			 * binding requests arrive on the RTP socket. read_rtp_packet()
+			 * processes them (advancing the DTLS state machine via do_dtls())
+			 * but sets bytes=0 because they are not RTP data.
+			 *
+			 * Without this patch, rtp_common_read() never returns a frame:
+			 *
+			 *   1. poll succeeds (ICE/STUN packet) -> got_rtp_poll=1
+			 *   2. read_rtp_packet() handles ICE/DTLS -> bytes=0
+			 *   3. Existing CNG return (~line 7780) checks !got_rtp_poll
+			 *      -> false (poll succeeded) -> skipped
+			 *   4. RTCP_MUX path requires has_rtcp=1 -> skipped for ICE
+			 *   5. Loop continues -> never returns -> read_frame blocks
+			 *
+			 * Because read_frame never returns, the originate loop never
+			 * reaches check_channel_status(). If the B leg terminates for
+			 * any reason (callee rejects, busy, timeout, caller cancels),
+			 * the A leg caller stays stuck in "dialing" until the originate
+			 * timeout fires (30-60s).
+			 *
+			 * Affected scenario:
+			 * ------------------
+			 * WebRTC softphone (A leg) calls out via bridge/originate.
+			 * The B leg can be a SIP provider (sending 180 Ringing with SDP,
+			 * triggering early media and DTLS setup) or another softphone
+			 * (via B2Bua). Any B leg termination during the A leg's DTLS
+			 * handshake window triggers this bug.
+			 *
+			 * Typical reproduction: WebRTC client unreachable on its RTP
+			 * address (e.g. wrong network adapter), so DTLS never completes.
+			 * Callee declines -> caller stays stuck.
+			 *
+			 * Fix:
+			 * ----
+			 * Return a CNG (comfort noise) frame when:
+			 *   - DTLS is active but not yet ready (state != DS_READY)
+			 *   - No actual RTP bytes were received (!bytes)
+			 *   - Blocking I/O mode (same guard as other CNG returns)
+			 *   - No DTMF output in progress (same guard as other CNG returns)
+			 *
+			 * This unblocks read_frame, allowing the originate loop to call
+			 * check_channel_status() and detect B leg termination promptly.
+			 *
+			 * Safety:
+			 * -------
+			 * - CNG frames are returned in multiple other code paths in this
+			 *   function. All callers (originate, bridge, conference) handle
+			 *   them. The caller hears ringback, not the CNG frame.
+			 * - DTLS still progresses: do_dtls() runs inside read_rtp_packet()
+			 *   on every iteration BEFORE this point. The CNG return fires
+			 *   after the packet is fully processed.
+			 * - No impact on established calls: once DTLS completes
+			 *   (state == DS_READY), this condition stops matching.
+			 * - No impact on non-WebRTC calls: requires rtp_session->dtls
+			 *   to be set.
+			 * - media_timeout/rtp_timeout_sec do NOT help because ICE/STUN
+			 *   packets keep resetting the media timer.
+			 */
+			if (!bytes && rtp_session->dtls && rtp_session->dtls->state != DS_READY &&
+				(!(io_flags & SWITCH_IO_FLAG_NOBLOCK)) &&
+				(rtp_session->dtmf_data.out_digit_dur == 0)) {
+				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(rtp_session->session), SWITCH_LOG_DEBUG,
+					"C4B patch: returning CNG frame during DTLS handshake (dtls_state=%d, got_rtp_poll=%d)\n",
+					rtp_session->dtls->state, got_rtp_poll);
+				return_cng_frame();
+			}
+
 		} else {
 
 			if (!switch_rtp_ready(rtp_session)) {


### PR DESCRIPTION
If media connections of one Leg of a call can not be established the Leg will stop listening to control commands sent via a SIP and therefore continue to live endlessly in freeswitch until the legs are force killed (which can only be done manually)


See Bug https://dev.azure.com/c4bag/C4B%20UC/_workitems/edit/15576) and https://dev.azure.com/c4bag/C4B%20UC/_workitems/edit/14544 for a detailed description.